### PR TITLE
教學說明文的建設改為建築

### DIFF
--- a/Core/DefInjected/ConceptDef/Concepts_NotedSelfshow.xml
+++ b/Core/DefInjected/ConceptDef/Concepts_NotedSelfshow.xml
@@ -154,7 +154,7 @@
   <!-- EN: Stockpiles -->
   <Stockpiles.label>規劃儲存區</Stockpiles.label>
   <!-- EN: Your colonists need somewhere to store items. Designate a STOCKPILE for them to store things.\n\nFind the stockpile in the ZONES section of the ARCHITECT menu in the lower-left. -->
-  <Stockpiles.helpText>你的居民需要一些儲存區才能存放資源，替他們設置一些儲存區以存放資源。\n\n從畫面左下處「建設」選單中的「區域」子選單中找到「儲存區」項目。</Stockpiles.helpText>
+  <Stockpiles.helpText>你的居民需要一些儲存區才能存放資源，替他們設置一些儲存區以存放資源。\n\n從畫面左下處「建築」選單中的「區域」子選單中找到「儲存區」項目。</Stockpiles.helpText>
   
   <!-- EN: Storage tab -->
   <StorageTab.label>儲存設定</StorageTab.label>


### PR DESCRIPTION
# 教學說明文的建設改為建築
<!--
    更新的主旨,同時也是PR標題
    ex: 新增核心翻譯, 修改README等等
-->
修改核心遊戲

## 更新內容
<!--
    簡易敘述更新內容即可
    ex: 修改錯字
-->
教學的說明文提到的"建設"按鈕改為"建築"
